### PR TITLE
batches: update k8s manifest in repos (demo)

### DIFF
--- a/resources/persistent-volumes/hostpath/k8s/deployments.yaml
+++ b/resources/persistent-volumes/hostpath/k8s/deployments.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/resources/persistent-volumes/hostpath/k8s/pods.yaml
+++ b/resources/persistent-volumes/hostpath/k8s/pods.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
Not my first batch change.

Add namespace and modify metadata annotations.

This is an arbitrary script used to insert some made up values that Bolaji created into
kubernetes spec files. 
The script doesn't explicitly check which YAML is used by k8s because it assumes every YAML
in the `sourcegraph-testing/k8s-examples` repo is a kubernetes spec file.



  @BolajiOlajide please check this out.

  #### Added Files
  
    - resources/persistent-volumes/hostpath/k8s/deployments.yaml

  
    - resources/persistent-volumes/hostpath/k8s/pods.yaml

[_Created by Sourcegraph batch change `bolaji.olajide/demo-7-jul`._](https://demo.sourcegraph.com/users/bolaji.olajide/batch-changes/demo-7-jul)